### PR TITLE
Pillar parallax layers go in front

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -22,7 +22,7 @@ oquonie.hiversaires { background-color:lightgrey; }
 
 stage { width:100vh; height:100vh; position:absolute; left:calc(50% - (100vh/2)); top:calc(50% - (100vh/2)); }
 stage room { width:100%; height:100%; margin-top:5vh; position: relative; }
-stage parallax { width: 100%;height: 100%;margin-top: 5vh;position: absolute;background-position: center center;background-size:contain; background-repeat:no-repeat;}
+stage parallax { width: 100%;height: 100%;margin-top: 5vh;position: absolute;background-position: center center;background-size:contain; background-repeat:no-repeat; z-index: 2000}
 stage parallax.over { background-image:url(../media/graphics/effects/parallax.1.png); }
 stage parallax.under { background-image:url(../media/graphics/effects/parallax.2.png); }
 .black stage parallax.over { background-image:url(../media/graphics/effects/parallax.3.png); }

--- a/scripts/core/stage.js
+++ b/scripts/core/stage.js
@@ -39,7 +39,7 @@ function Stage()
     oquonie.player.move_at(x,y);
     
     var numPillars = oquonie.spellbook.pillars.length;
-    var theme = numPillars >= 5 ? "black" : this.room.theme;
+    var theme = (numPillars >= 5 && this.room.theme != "pillars") ? "black" : this.room.theme;
 
     oquonie.stage.set_theme(theme);
 
@@ -127,6 +127,8 @@ function Stage()
   this.set_theme = function(theme)
   {
     oquonie.element.setAttribute("class",theme);
+
+    $(this.room.element).css("z-index", (theme == "pillars" ? 1000 : 3000))
   }
 
   //
@@ -157,7 +159,7 @@ function Stage()
 
   this.load_room = function(room_id,x,y)
   {
-    console.log("Entering Room: "+room_id);
+    console.log("Loading Room: "+room_id);
 
     if(!oquonie.world.rooms[room_id]){
       console.warn("Missing room:("+room_id+")");
@@ -174,7 +176,7 @@ function Stage()
     oquonie.player.move_at(x,y);
 
     var numPillars = oquonie.spellbook.pillars.length;
-    var theme = numPillars >= 5 ? "black" : this.room.theme;
+    var theme = (numPillars >= 5 && this.room.theme != "pillars") ? "black" : this.room.theme;
     oquonie.stage.set_theme(theme);
 
     this.look();


### PR DESCRIPTION
Father's Day PR #3:

In the iOS version of the game, the red and cyan streaks appear above the pillar rooms. This brings back that functionality by changing the z-index of a room depending on its theme.

As always, please don't feel any pressure to accept any change you're not into. 👍