### PR TITLE
Art timing and preload

### DIFF
--- a/scripts/core/animator.js
+++ b/scripts/core/animator.js
@@ -5,6 +5,7 @@ function Animator(host)
   this.state = "idle";
   this.orientation = null;
   this.last_art_id = null;
+  this.preload_container = document.createElement("preload");
 
   this.add = function(animation)
   {
@@ -30,6 +31,23 @@ function Animator(host)
     
     $(this.host.element).css('background-size',(width*frames)+"px "+(width*1.5)+"px");
     $(this.host.element).css('background-position',(anim.run() * -width + width)+"px center");
+  }
+
+  this.preload = function()
+  {
+    $(this.preload_container).css("display", "none");
+    oquonie.element.appendChild(this.preload_container);
+    while (this.preload_container.lastChild != null) {
+      this.preload_container.removeChild(this.preload_container.lastChild);
+    }
+
+    for (var animName in this.animations)
+    {
+      var art_id = "media/graphics/"+this.host.name+"/"+(this.host.id ? this.host.id+"." : "")+animName+".png";
+      var image = new Image();
+      image.src = art_id;
+      this.preload_container.appendChild(image);
+    }
   }
 
   this.set_state = function(new_state, update_immediately = true)

--- a/scripts/core/animator.js
+++ b/scripts/core/animator.js
@@ -31,6 +31,15 @@ function Animator(host)
     $(this.host.element).css('background-size',(width*frames)+"px "+(width*1.5)+"px");
     $(this.host.element).css('background-position',(anim.run() * -width + width)+"px center");
   }
+
+  this.set_state = function(new_state, update_immediately = true)
+  {
+    this.state = new_state;
+    if (update_immediately)
+    {
+      this.animate();
+    }
+  }
 }
 
 function unique(list)

--- a/scripts/core/artbook.js
+++ b/scripts/core/artbook.js
@@ -28,6 +28,7 @@ function Artbook()
       
       this.stylesheet.insertRule("." + className + "{background-image:url("+asset_url+")}", 0);
       this.asset_catalog[asset_url] = className;
+      console.log("RULES:", this.stylesheet.cssRules.length, asset_url);
     }
 
     var id = this.get_element_id(selector);

--- a/scripts/core/artbook.js
+++ b/scripts/core/artbook.js
@@ -28,7 +28,6 @@ function Artbook()
       
       this.stylesheet.insertRule("." + className + "{background-image:url("+asset_url+")}", 0);
       this.asset_catalog[asset_url] = className;
-      console.log("RULES:", this.stylesheet.cssRules.length, asset_url);
     }
 
     var id = this.get_element_id(selector);

--- a/scripts/core/event.js
+++ b/scripts/core/event.js
@@ -97,8 +97,7 @@ function Event(subtype)
     var animator = this.animator;
     if(x == 0 && y == -1 || x == -1 && y == 0){ animator.set_state("idle.front"); }
     if(x == 0 && y == 1 || x == 1 && y == 0){ animator.set_state("idle.back"); }
-    animator.animate();
-
+    
     $(this.element).finish();
     var origin_pos_y = parseInt(this.element.style.top);
     $(this.element).css("top", (origin_pos_y-0.5)+"%").animate({ top: origin_pos_y+"%" }, oquonie.speed/2);
@@ -109,8 +108,7 @@ function Event(subtype)
     var animator = this.animator;
     if(x == 0 && y == -1 || x == -1 && y == 0){ animator.set_state("idle.front"); }
     if(x == 0 && y == 1 || x == 1 && y == 0){ animator.set_state("idle.back"); }
-    animator.animate();
-
+    
     var xSlant = x - y;
     var ySlant = (-x - y) * 0.5;
 

--- a/scripts/core/event.js
+++ b/scripts/core/event.js
@@ -16,14 +16,13 @@ function Event(subtype)
     var _y = p[0];
     var _x = p[1];
     var _z = p[2];
-    var el = this.element;
-
+    
     var target = this.animator;
-    target.state = "walk.front";
+    target.set_state("walk.front");
     
     keyboard.lock("moving");
-    $(el).animate({ left: _x, top: _y }, oquonie.speed, function(){
-      target.state = "idle.front";
+    $(this.element).animate({ left: _x, top: _y }, oquonie.speed, function(){
+      target.set_state("idle.front");
       keyboard.unlock("moving");
     });
 
@@ -41,14 +40,14 @@ function Event(subtype)
     var _z = p[2];
 
     var target = this.animator;
-    target.state = "walk.front";
+    target.set_state("walk.front");
 
-    if(x == 0 && y == -1 || x == -1 && y == 0){ target.state = "walk.front"; }
-    if(x == 0 && y == 1 || x == 1 && y == 0){ target.state = "walk.back"; }
+    if(x == 0 && y == -1 || x == -1 && y == 0){ target.set_state("walk.front"); }
+    if(x == 0 && y == 1 || x == 1 && y == 0){ target.set_state("walk.back"); }
     
     $(this.element).animate({ left: _x, top: _y }, oquonie.speed, function(){
-      if(x == 0 && y == -1 || x == -1 && y == 0){ target.state = "idle.front"; }
-      if(x == 0 && y == 1 || x == 1 && y == 0){ target.state = "idle.back"; }
+      if(x == 0 && y == -1 || x == -1 && y == 0){ target.set_state("idle.front"); }
+      if(x == 0 && y == 1 || x == 1 && y == 0){ target.set_state("idle.back"); }
     });
     
     oquonie.stage.animate(this.x,this.y);
@@ -72,8 +71,8 @@ function Event(subtype)
     var target = this.animator;
     x = -x;
     y = -y;
-    if(x == 0 && y == -1 || x == -1 && y == 0){ target.state = "idle.front"; }
-    if(x == 0 && y == 1 || x == 1 && y == 0){ target.state = "idle.back"; }
+    if(x == 0 && y == -1 || x == -1 && y == 0){ target.set_state("idle.front"); }
+    if(x == 0 && y == 1 || x == 1 && y == 0){ target.set_state("idle.back"); }
     target.animate();
   }
 
@@ -96,8 +95,8 @@ function Event(subtype)
   this.bump_up = function(x,y)
   {
     var animator = this.animator;
-    if(x == 0 && y == -1 || x == -1 && y == 0){ animator.state = "idle.front"; }
-    if(x == 0 && y == 1 || x == 1 && y == 0){ animator.state = "idle.back"; }
+    if(x == 0 && y == -1 || x == -1 && y == 0){ animator.set_state("idle.front"); }
+    if(x == 0 && y == 1 || x == 1 && y == 0){ animator.set_state("idle.back"); }
     animator.animate();
 
     $(this.element).finish();
@@ -108,8 +107,8 @@ function Event(subtype)
   this.bump_against = function(x,y)
   {
     var animator = this.animator;
-    if(x == 0 && y == -1 || x == -1 && y == 0){ animator.state = "idle.front"; }
-    if(x == 0 && y == 1 || x == 1 && y == 0){ animator.state = "idle.back"; }
+    if(x == 0 && y == -1 || x == -1 && y == 0){ animator.set_state("idle.front"); }
+    if(x == 0 && y == 1 || x == 1 && y == 0){ animator.set_state("idle.back"); }
     animator.animate();
 
     var xSlant = x - y;

--- a/scripts/core/game.js
+++ b/scripts/core/game.js
@@ -36,7 +36,7 @@ function Game()
   {
     console.info("Loading..");
 
-    oquonie.player.id = localStorage.character;
+    oquonie.player.set_id(localStorage.character);
     oquonie.player.location = parseInt(localStorage.room);
 
     if(localStorage.ramen_necomedre == "true"){ oquonie.spellbook.add_ramen("necomedre")}
@@ -83,7 +83,7 @@ function Game()
     oquonie.spellbook.reset();
 
     oquonie.player.location = 29;
-    oquonie.player.id = "necomedre";
+    oquonie.player.set_id("necomedre");
 
     return "Created a new game.";
   }

--- a/scripts/core/walkthrough.js
+++ b/scripts/core/walkthrough.js
@@ -143,7 +143,7 @@ function Walkthrough()
   this.manual = function()
   {
     oquonie.speed = 300;
-    oquonie.player.id = "nastazie";
+    oquonie.player.set_id("nastazie");
     oquonie.player.location = 142;
     
     oquonie.spellbook.add_ramen("necomedre")
@@ -164,7 +164,7 @@ function Walkthrough()
 
   this.walk_all = function()
   {
-    oquonie.player.id = "necomedre";
+    oquonie.player.set_id("necomedre");
     this.room = 29;
     this.inputs = chapter_all;
     oquonie.stage.enter_room(this.room);
@@ -173,7 +173,7 @@ function Walkthrough()
 
   this.walk_chapter0 = function()
   {
-    oquonie.player.id = "necomedre";
+    oquonie.player.set_id("necomedre");
     this.room = 29;
     this.inputs = chapter_0;
     oquonie.stage.enter_room(this.room);
@@ -182,7 +182,7 @@ function Walkthrough()
 
   this.walk_chapter1 = function()
   {
-    oquonie.player.id = "necomedre";
+    oquonie.player.set_id("necomedre");
     this.room = 1;
     this.inputs = chapter_1;
     oquonie.stage.enter_room(this.room);
@@ -191,7 +191,7 @@ function Walkthrough()
 
   this.walk_chapter2 = function()
   {
-    oquonie.player.id = "necomedre";
+    oquonie.player.set_id("necomedre");
     this.room = 9;
     this.inputs = chapter_2;
     oquonie.stage.enter_room(this.room);
@@ -200,7 +200,7 @@ function Walkthrough()
 
   this.walk_chapter3 = function()
   {
-    oquonie.player.id = "necomedre";
+    oquonie.player.set_id("necomedre");
     this.room = 3;
     this.inputs = chapter_3;
     oquonie.stage.enter_room(this.room);
@@ -209,7 +209,7 @@ function Walkthrough()
 
   this.walk_chapter4 = function()
   {
-    oquonie.player.id = "nastazie";
+    oquonie.player.set_id("nastazie");
     this.room = 4;
     this.inputs = chapter_4;
     oquonie.stage.enter_room(this.room);
@@ -218,7 +218,7 @@ function Walkthrough()
 
   this.walk_secrets = function()
   {
-    oquonie.player.id = "nastazie";
+    oquonie.player.set_id("nastazie");
     this.room = 1;
     this.inputs = secrets;
 

--- a/scripts/event/boss.js
+++ b/scripts/event/boss.js
@@ -27,7 +27,7 @@ function Boss(x,y)
     setTimeout(function(){ oquonie.stage.set_theme("black"); }, 2300);
     setTimeout(function(){ keyboard.unlock("boss"); }, 7000);
 
-    this.animator.state = "ghost";
+    this.animator.set_state("ghost");
 
     $(this.element).delay(oquonie.speed * 8).animate({ marginTop: -35+"%", opacity:0 }, oquonie.speed * 2);
     this.is_gone = true;

--- a/scripts/event/player.js
+++ b/scripts/event/player.js
@@ -2,7 +2,7 @@ function Player()
 {
   Event.call(this,"player");
 
-  this.id = "necomedre";
+  this.id = "";
   this.orientation = "front";
 
   this.animator.add(new Animation("idle.front",[1,1,1,1,1,2,3,2]));
@@ -15,6 +15,15 @@ function Player()
   this.shadow = new Shadow();
 
   this.element.appendChild(this.shadow.element);
+
+  this.set_id = function(new_id)
+  {
+    if (this.id != new_id)
+    {
+      this.id = new_id;
+      this.animator.preload();
+    }
+  }
 
   this.try_move = function(x,y)
   {
@@ -147,7 +156,7 @@ function Player()
   {
     console.log("Transform(char): "+spell);
 
-    oquonie.player.id = spell;
+    oquonie.player.set_id(spell);
     oquonie.stage.look();
 
     $(oquonie.player.element).animate({ opacity:1 }, oquonie.speed*2).delay(1000).animate({ top: oquonie.player.position_at(oquonie.player.x,oquonie.player.y)[0] }, oquonie.speed*8, function(){

--- a/scripts/event/player.js
+++ b/scripts/event/player.js
@@ -101,7 +101,7 @@ function Player()
 
   this.lift = function(speed)
   {
-    this.animator.state = "warp";
+    this.animator.set_state("warp");
 
     $(oquonie.player.element).delay(300).animate({ top: (parseInt(this.position_at(this.x,this.y)[0])*0.9)+"%" }, speed);
     $(oquonie.player.shadow.element).delay(300).animate({ top: 10+"%", opacity:0 },speed/2);
@@ -109,7 +109,7 @@ function Player()
 
   this.land = function()
   {
-    $(oquonie.player.element).css("top",(parseInt(this.position_at(this.x,this.y)[0])*0.6)+"%").delay(300).animate({ top: (parseInt(this.position_at(this.x,this.y)[0]))+"%" }, oquonie.speed*10, function(){ oquonie.player.animator.state = "idle.front"; });
+    $(oquonie.player.element).css("top",(parseInt(this.position_at(this.x,this.y)[0])*0.6)+"%").delay(300).animate({ top: (parseInt(this.position_at(this.x,this.y)[0]))+"%" }, oquonie.speed*10, function(){ oquonie.player.animator.set_state("idle.front"); });
     $(oquonie.player.shadow.element).css("top",(parseInt(this.position_at(this.x,this.y)[0])*1.4)+"%").delay(300).animate({ top: 0+"%", opacity:1 }, oquonie.speed*10);
   }
 
@@ -124,7 +124,7 @@ function Player()
       oquonie.game.save();
     }
 
-    this.animator.state = "warp";
+    this.animator.set_state("warp");
 
     oquonie.music.play_effect("transform");
 
@@ -160,7 +160,7 @@ function Player()
   {
     console.log("Transform(done)");
     keyboard.unlock("transform");
-    oquonie.player.animator.state = "idle.front";
+    oquonie.player.animator.set_state("idle.front");
   }
 
   this.update(20);

--- a/scripts/event/shark.js
+++ b/scripts/event/shark.js
@@ -34,15 +34,15 @@ function Shark(x,y,is_transformer = true)
 
   this.on_sight = function()
   {
-    this.animator.state = "away";
+    var animation_state = "away";
 
     if(this.is_transformer == true && oquonie.player.id != "necomedre"){
-      this.animator.state = "active";
+      animation_state = "active";
     }
     else if(oquonie.spellbook.spells.length > 0){
-      this.animator.state = "active";
+      animation_state = "active";
     }
-    this.animator.animate();
+    this.animator.set_state(animation_state);
   }
 
   this.update(20);

--- a/scripts/event/speaker.js
+++ b/scripts/event/speaker.js
@@ -40,14 +40,14 @@ function Speaker(x,y,id = "disc")
   this.play = function()
   {
     this.is_playing = true;
-    this.animator.state = "on";
+    this.animator.set_state("on");
     oquonie.music.resume_ambience();
   }
 
   this.stop = function()
   {
     this.is_playing = false;
-    this.animator.state = "off";
+    this.animator.set_state("off");
     oquonie.music.pause_ambience();
   }
 


### PR DESCRIPTION
Just fixed a sneaky issue I'd been wary of for a while; whenever the player walked, we would animate and mirror the position appropriately, but would only update their appearance to the first frame of the walk cycle after a few tenths of a second– because the animators are on a 200ms timer, whereas the movement code responds immediately to keypresses.

It actually looked like a nuanced turn animation, half the time. But only half. :D The game now forces the first animation frame to display whenever an animation's state changes.

This revealed a _second_ issue– the player's art assets sometimes wouldn't load until after they were needed, resulting in a momentary "art blip". So animators now have a preload method, which populates a set of unseen Image elements with the images corresponding to its states. For now this is only used in the player's new set_id method, but it gets rid of the art blips.