### PR TITLE
Prevent scrolling by hiding overflow

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -2,7 +2,7 @@ body { background:#eee; overflow: hidden }
 
 oquonie, stage, room, tile, dialog, spellbook, spell, parallax { display:block; }
 
-oquonie { width:100vw; height:100vh; transition: background-color 1s; }
+oquonie { width:100vw; height:100vh; transition: background-color 1s; position: relative; overflow: hidden;}
 
 dialog { width:100vw; height:100vh;  z-index:9000; background: RGBA(0,0,0,0.5); position: fixed; opacity: 0 }
 dialog portrait, oquonie dialog bubble { display:block; width:400px; height:400px; left:50%; top:50%; margin-top:-200px; margin-left:-200px; background-size:contain; background-position:center bottom; background-repeat:no-repeat; position:absolute; z-index:9000; }


### PR DESCRIPTION
I had problem with overflow making the body larger than the screen. This fixes it.