### PR TITLE
Performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
     <!-- <script type="text/javascript" src="scripts/jquery.js"></script> -->
     <script type="text/javascript" src="scripts/jquery-3.2.1.min.js"></script>

--- a/links/main.css
+++ b/links/main.css
@@ -4,7 +4,7 @@ oquonie, stage, room, tile, dialog, spellbook, spell, parallax { display:block; 
 
 oquonie { width:100vw; height:100vh; transition: background-color 1s; }
 
-dialog { width:100vw; height:100vh;  z-index:9000; background: RGBA(0,0,0,0.5); position: fixed; opacity: 0 }
+dialog { width:100vw; height:100vh;  z-index:9000; background: RGBA(0,0,0,0.5); position: fixed; opacity: 0; will-change: opacity; }
 dialog portrait, oquonie dialog bubble { display:block; width:400px; height:400px; left:50%; top:50%; margin-top:-200px; margin-left:-200px; background-size:contain; background-position:center bottom; background-repeat:no-repeat; position:absolute; z-index:9000; }
 dialog bubble { background-image:url(../media/graphics/interface/bubble.png); }
 dialog bubble letter { display:block; position:absolute; bottom:5%; width:75px; height:75px; background-size:contain; background-position: center center; bottom: 35px}
@@ -21,9 +21,9 @@ oquonie.pillars { background-color:lightgrey; }
 oquonie.hiversaires { background-color:lightgrey; }
 oquonie.tear { background-color:lightgrey; }
 
-stage { width:100vh; height:100vh; position:absolute; left:calc(50% - (100vh/2)); top:calc(50% - (100vh/2)); }
+stage { width:100vh; height:100vh; position:absolute; left:calc(50% - (100vh/2)); top:calc(50% - (100vh/2)); will-change:top,left,transform; }
 stage room { width:100%; height:100%; margin-top:5vh; position: relative; }
-stage parallax { width: 100%;height: 100%;margin-top: 5vh;position: absolute;background-position: center center;background-size:contain; background-repeat:no-repeat; z-index: 2000}
+stage parallax { width: 100%;height: 100%;margin-top: 5vh;position: absolute;background-position: center center;background-size:contain; background-repeat:no-repeat; z-index: 2000; will-change: transform; }
 stage parallax.over { background-image:url(../media/graphics/effects/parallax.1.png); }
 stage parallax.under { background-image:url(../media/graphics/effects/parallax.2.png); }
 .black stage parallax.over { background-image:url(../media/graphics/effects/parallax.3.png); }
@@ -32,7 +32,7 @@ stage parallax.under { background-image:url(../media/graphics/effects/parallax.2
 .tear stage parallax.under { background-image:url(../media/graphics/effects/parallax.5.png); }
 .pillars stage parallax.over { background-image:url(../media/graphics/effects/parallax.7.png); }
 .pillars stage parallax.under { background-image:url(../media/graphics/effects/parallax.6.png); }
-tile,notification { background-size:100%; background-position:0px center; background-repeat:repeat-x; position:absolute; width:20%; height:40%; margin-left:-10%;}
+tile,notification { background-size:100%; background-position:0px center; background-repeat:repeat-x; position:absolute; width:20%; height:40%; margin-left:-10%; will-change: top,left,opacity;}
 tile.floor {  margin-top:-20%; } 
 tile.wall {margin-top:-30%; }
 tile.wall.left { -webkit-transform: scaleX(-1); transform: scaleX(-1);}
@@ -43,4 +43,4 @@ tile.event.mirror { -webkit-transform: scaleX(-1); transform: scaleX(-1); }
 tile.shadow { background-image:url(../media/graphics/player/shadow.png); width:100%; height:100%; margin-left:0px; position: absolute; top:0px; z-index:5;}
 tile.event notification { width:100%;height:100%;top:-15%; left:10%; }
 
-overlay { position:absolute; display:block; width:100vw; height:100vh; z-index:8000; background-size:contain; background-position:center center; background-repeat: no-repeat; background-color: white; top:0px; left:0px; opacity:0;}
+overlay { position:absolute; display:block; width:100vw; height:100vh; z-index:8000; background-size:contain; background-position:center center; background-repeat: no-repeat; background-color: white; top:0px; left:0px; opacity:0; will-change: opacity;}

--- a/scripts/core/stage.js
+++ b/scripts/core/stage.js
@@ -111,20 +111,26 @@ function Stage()
 
   this.animate = function(x,y)
   {
-    var xSlant = x - y;
-    var ySlant = -x - y;
-    $(this.element).transition({ marginLeft: (xSlant * 0.5)+"%",marginTop: (ySlant * 0.5)+"%" }, oquonie.speed);
-    $(this.parallax_over).transition({ marginLeft: (xSlant * 1.0)+"%",marginTop: (ySlant * 1.0)+"%" }, oquonie.speed);
-    $(this.parallax_under).transition({ marginLeft: (xSlant * 0.125)+"%",marginTop: (ySlant * 0.125)+"%" }, oquonie.speed);
+    this.center(x,y);
   }
 
   this.center = function(x,y)
   {
     var xSlant = x - y;
     var ySlant = -x - y;
-    $(this.element).css("margin-left",(xSlant * 0.5)+"%").css("margin-top",(ySlant * 0.5)+"%");
-    $(this.parallax_over).transition({ marginLeft: (xSlant * 1.0)+"%",marginTop: (ySlant * 1.0)+"%" }, oquonie.speed);
-    $(this.parallax_under).transition({ marginLeft: (xSlant * 0.125)+"%",marginTop: (ySlant * 0.125)+"%" }, oquonie.speed);
+    this.move_parallax(this.element,        0.5,   xSlant, ySlant);
+    this.move_parallax(this.parallax_over,  1.0,   xSlant, ySlant);
+    this.move_parallax(this.parallax_under, 0.125, xSlant, ySlant);
+  }
+
+  this.move_parallax = function(e, mult, x, y)
+  {
+    $(e).css({
+      "transition" : "transform " + (oquonie.speed/1000)+"s",
+      "-webkit-transition" : "-webkit-transform " + (oquonie.speed/1000)+"s",
+      "transform" : "translate("+(mult*x)+"%,"+(mult*y)+"%)",
+      "-webkit-transform" : "translate("+(mult*x)+"%,"+(mult*y)+"%)"
+    });
   }
 
   this.set_theme = function(theme)


### PR DESCRIPTION
Set viewport meta so that android WebView can use GPU rasterization (improves perf a lot), more here: https://www.chromium.org/developers/design-documents/chromium-graphics/how-to-get-gpu-rasterization

Use transform instead of top/left for parallax. Makes everything fast and floor tiles move smoothly instead of jumping pixel by pixel separately.

Add some `will-change` css to tell browser which elements should be separate compositing layers. Improves performance a lot.